### PR TITLE
Fix: 某些时候cargo tt 会卡住

### DIFF
--- a/tool/src/build.rs
+++ b/tool/src/build.rs
@@ -19,8 +19,8 @@ fn make(verbose: bool, args: &Vec<&str>) -> std::io::Result<()> {
     child.current_dir(MAKE_DIR).stdin(process::Stdio::piped());
     if !verbose {
         child
-            .stdout(process::Stdio::piped())
-            .stderr(process::Stdio::piped());
+            .stdout(process::Stdio::null())
+            .stderr(process::Stdio::null());
     }
     let mut child = child.args(args).spawn()?;
     child.wait()?;


### PR DESCRIPTION
当编译报错过长时管道错误，子进程无法正常结束，父进程wait()无限等待。改为null()即可