### PR TITLE
Fix: make failed

### DIFF
--- a/user/utests.mk
+++ b/user/utests.mk
@@ -21,6 +21,7 @@ TARGETS := $(OBJS:%.o=%)
 TEST_DIR := $(BUILD_DIR)/user
 
 $(BUILD_DIR)/%.S: %.pl
+	@ mkdir -p $(dir $@)
 	perl $^ > $@
 
 $(BUILD_DIR)/%.o: $(BUILD_DIR)/%.S


### PR DESCRIPTION
Running `make` in first time will cause "/bin/sh: 1: cannot create build/user/lib/usys.S: Directory nonexistent". This PR fix this bug by adding  `@ mkdir -p $(dir $@)` rule to makefile `user/utests.mk`